### PR TITLE
Add Alacritty themes

### DIFF
--- a/extra/alacritty-catpuccino.yml
+++ b/extra/alacritty-catpuccino.yml
@@ -1,0 +1,35 @@
+# Catpuccino
+colors:
+  # Default colors
+  primary:
+    background: '0x0e171c'
+    foreground: '0xabb2bf'
+
+  # Colors the cursor will use if `custom_cursor_colors` is true
+  cursor:
+    text: '0x0e171c'
+    cursor: '0xabb2bf'
+
+  # Normal colors
+  normal:
+    black:   '0x393b44'
+    red:     '0xc94f6d'
+    green:   '0x97c374'
+    yellow:  '0xdbc074'
+    blue:    '0x61afef'
+    magenta: '0xc678dd'
+    cyan:    '0x63cdcf'
+    white:   '0xdfdfe0'
+
+  # Bright colors
+  bright:
+    black:   '0x7f8c98'
+    red:     '0xe06c75'
+    green:   '0x58cd8b'
+    yellow:  '0xffe37e'
+    blue:    '0x84cee4'
+    magenta: '0xb8a1e3'
+    cyan:    '0x59f0ff'
+    white:   '0xfdebc3'
+
+  # indexed_colors: []

--- a/extra/alacritty-light-melya.yml
+++ b/extra/alacritty-light-melya.yml
@@ -1,0 +1,35 @@
+# Catppuccino Light Melya
+colors:
+  # Default colors
+  primary:
+    background: '0xfbfbfb'
+    foreground: '0x0e171c'
+
+  # Colors the cursor will use if `custom_cursor_colors` is true
+  cursor:
+    text: '0x0e171c'
+    cursor: '0xfbfbfb'
+
+  # Normal colors
+  normal:
+    black:   '0x393b44'
+    red:     '0xb0304e'
+    green:   '0x76ab49'
+    yellow:  '0xffce1f'
+    blue:    '0x157c8e'
+    magenta: '0xa414cc'
+    cyan:    '0x63cdcf'
+    white:   '0xdfdfe0'
+
+  # Bright colors
+  bright:
+    black:   '0x7f8c98'
+    red:     '0xd84652'
+    green:   '0x58cd8b'
+    yellow:  '0xffe37e'
+    blue:    '0x84cee4'
+    magenta: '0xb8a1e3'
+    cyan:    '0x59f0ff'
+    white:   '0x0e171c'
+
+  # indexed_colors: []

--- a/extra/alacritty-neon-latte.yml
+++ b/extra/alacritty-neon-latte.yml
@@ -1,0 +1,35 @@
+# Catppuccino Light Melya
+colors:
+  # Default colors
+  primary:
+    background: '0x150b26'
+    foreground: '0xfdebc3'
+
+  # Colors the cursor will use if `custom_cursor_colors` is true
+  cursor:
+    text: '0xfdebc3'
+    cursor: '0x150b26'
+
+  # Normal colors
+  normal:
+    black:   '0x393b44'
+    red:     '0xcf4f6d'
+    green:   '0x51ee72'
+    yellow:  '0xffe070'
+    blue:    '0x96e2f0'
+    magenta: '0xd97bf2'
+    cyan:    '0x63cdcf'
+    white:   '0xdfdfe0'
+
+  # Bright colors
+  bright:
+    black:   '0x7f8c98'
+    red:     '0xe06c75'
+    green:   '0x58cd8b'
+    yellow:  '0xffe37e'
+    blue:    '0x84cee4'
+    magenta: '0xb8a1e3'
+    cyan:    '0x59f0ff'
+    white:   '0xfdebc3'
+
+  # indexed_colors: []


### PR DESCRIPTION
This PR adds some themes for Alacritty!

Some questions:

1. I noticed some extended colors in #8, should those be replicated here?
2. I noticed that the actual background of the text editor area in neovim is darker than the `bg` color listed in `catppuccino.lua`. In my personal Alacritty configuration I used `#121212` as the background so it would be darker to match neovim. Do you have a preference?
3. It looks like in the lua files in the middle of all the bright colors the bright red color is called `red_bg` -- is this intentional? The other bright colors surrounding it are all called `_br`.