### PR TITLE
Fix typo in lualine theme replace mode

### DIFF
--- a/lua/lualine/themes/catppuccino.lua
+++ b/lua/lualine/themes/catppuccino.lua
@@ -31,8 +31,8 @@ catppuccino.visual = {
 }
 
 catppuccino.replace = {
-	a = { bg = cpt.red_bg, fg = cpt.black },
-	b = { bg = cpt.fg_gutter, fg = cpt.red_bg },
+	a = { bg = cpt.red_br, fg = cpt.black },
+	b = { bg = cpt.fg_gutter, fg = cpt.red_br },
 }
 
 catppuccino.inactive = {


### PR DESCRIPTION
cpt.red_bg does not exist, it probably was meant to be cpt.red_br.