### PR TITLE
Define hop colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ integrations = {
 	markdown = false,
 	lightspeed = false,
 	ts_rainbow = false,
+	hop = false,
 }
 ```
 
@@ -242,6 +243,7 @@ catppuccino.setup(
 			markdown = false,
 			lightspeed = false,
 			ts_rainbow = false,
+			hop = false,
 		}
 	}
 )
@@ -302,6 +304,7 @@ catppuccino.setup(
 			markdown = false,
 			lightspeed = false,
 			ts_rainbow = false,
+			hop = false,
 		}
 	}
 )

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
     -   [Lightspeed](https://github.com/ggandor/lightspeed.nvim)
     -   [Nvim-ts-Rainbow](https://github.com/p00f/nvim-ts-rainbow)
     -   [Sneak](https://github.com/justinmk/vim-sneak)
+    -   [Hop](https://github.com/phaazon/hop.nvim)
     -   [Neogit](https://github.com/TimUntersberger/neogit)
     -   [Indent Blankline](https://github.com/lukas-reineke/indent-blankline.nvim)
     -   [Kitty](https://github.com/kovidgoyal/kitty)

--- a/lua/catppuccino/config.lua
+++ b/lua/catppuccino/config.lua
@@ -43,6 +43,7 @@ config.options = {
 		markdown = false,
 		lightspeed = false,
 		ts_rainbow = false,
+		hop = false,
 	},
 }
 

--- a/lua/catppuccino/core/integrations/hop.lua
+++ b/lua/catppuccino/core/integrations/hop.lua
@@ -4,10 +4,10 @@ local M = {}
 
 function M.get(cpt)
 	return {
-		HopNextKey = {bg = cpt.bg, fg = cpt.orange, style = "bold"},
-		HopNextKey1 = {bg = cpt.bg, fg = cpt.blue, style = "bold"},
-		HopNextKey2 = {bg = cpt.bg, fg = util.darken(cpt.blue, 0.80, cpt.bg)},
-		HopUnmatched = {bg = cpt.bg, fg = cpt.comment},
+		HopNextKey = { bg = cpt.bg, fg = cpt.orange, style = "bold" },
+		HopNextKey1 = { bg = cpt.bg, fg = cpt.blue, style = "bold" },
+		HopNextKey2 = { bg = cpt.bg, fg = util.darken(cpt.blue, 0.80, cpt.bg) },
+		HopUnmatched = { bg = cpt.bg, fg = cpt.comment },
 	}
 end
 

--- a/lua/catppuccino/core/integrations/hop.lua
+++ b/lua/catppuccino/core/integrations/hop.lua
@@ -1,0 +1,14 @@
+local util = require("catppuccino.utils.util")
+
+local M = {}
+
+function M.get(cpt)
+	return {
+		HopNextKey = {bg = cpt.bg, fg = cpt.orange, style = "bold"},
+		HopNextKey1 = {bg = cpt.bg, fg = cpt.blue, style = "bold"},
+		HopNextKey2 = {bg = cpt.bg, fg = util.darken(cpt.blue, 0.80, cpt.bg)},
+		HopUnmatched = {bg = cpt.bg, fg = cpt.comment},
+	}
+end
+
+return M


### PR DESCRIPTION
Defined colors for hop.nvim

Default hop colors  (with dark_catppuccino) :
![Screenshot from 2021-09-03 09-10-12](https://user-images.githubusercontent.com/43147494/131947515-c837a30d-0e27-4479-b198-e7d45ca17bf3.png)

After this commit
dark_catppuccino:
![Screenshot from 2021-09-03 09-10-30](https://user-images.githubusercontent.com/43147494/131947575-bc00379c-bce7-408b-99dc-ccd475a019c4.png)

soft_manilo
![Screenshot from 2021-09-03 09-10-51](https://user-images.githubusercontent.com/43147494/131947589-4529485c-ea08-4e6a-9c8b-abd5b056689d.png)

neon_latte
![Screenshot from 2021-09-03 09-11-04](https://user-images.githubusercontent.com/43147494/131947603-994a5efc-4cb9-41ee-9360-3e04f8aaf25b.png)

light_melya
![Screenshot from 2021-09-03 09-11-30](https://user-images.githubusercontent.com/43147494/131947617-ecaa8cd8-c3c8-41ad-a838-486f70b57e92.png)

In my opinion these colors look good in the dark themes, but not so good in light_melya.  Is it possible to define different colors only for light_melya?

