### PR TITLE
Fix lightline not finding colorscheme

### DIFF
--- a/autoload/lightline/colorscheme/catppuccino.vim
+++ b/autoload/lightline/colorscheme/catppuccino.vim
@@ -1,0 +1,2 @@
+let g:lightline#colorscheme#catppuccino#palette = lightline#colorscheme#fill(
+      \ luaeval('require("lightline.colorscheme.catppuccino")'))


### PR DESCRIPTION
This fixes the issue where lightline complains it can't find the catppuccino colorscheme.

The colorscheme must be stored in a global variable that lightline expects.
