### PR TITLE
Respect transparency by providing a value for cp.none

### DIFF
--- a/lua/katppuccino/core/mapper.lua
+++ b/lua/katppuccino/core/mapper.lua
@@ -18,7 +18,7 @@ end
 
 local function get_base()
 	local cp = color_palette
-    cp.none = "NONE"
+	cp.none = "NONE"
 
 	return {
 		Comment = { fg = cp.katppuccino11, style = cnf.styles.comments }, -- just comments

--- a/lua/katppuccino/core/mapper.lua
+++ b/lua/katppuccino/core/mapper.lua
@@ -18,6 +18,7 @@ end
 
 local function get_base()
 	local cp = color_palette
+    cp.none = "NONE"
 
 	return {
 		Comment = { fg = cp.katppuccino11, style = cnf.styles.comments }, -- just comments


### PR DESCRIPTION
With the refactor removing values from the color mapper table,
the missing value on cp.none prevents transparency from being
respected.  This adds a value for that in a core.mapper close
to where it is used and does not pollute th color mapping table.

